### PR TITLE
fix `additional_dependencies` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When using plugins with `prettier` you'll need to declare them under
     -   id: prettier
         additional_dependencies:
         -   prettier@2.1.2
-        -   @prettier/plugin-xml@0.12.0
+        -   '@prettier/plugin-xml@0.12.0'
 ```
 
 By default, all files are passed to `prettier`, if you want to limit the


### PR DESCRIPTION
Possible typo? Is this missing quotes? Sorry, I have not checked this carefully… Just stumbled over a `pre_commit.clientlib.InvalidConfigError` exception, using the following based on the README:

```yaml
- repo: https://github.com/pre-commit/mirrors-prettier
  rev: master
  hooks:
    - id: prettier
      types: [markdown, html, javascript, css]
      additional_dependencies:
        - prettier@2.1.2
        - @prettier/plugin-xml@0.12.0
```

Which bails on me like this:

```
poetry run pre-commit run --all-files
An error has occurred: InvalidConfigError:
==> File .pre-commit-config.yaml
=====> while scanning for the next token
found character '@' that cannot start any token
  in "<unicode string>", line 46, column 15:
              -   @prettier/plugin-xml@0.12.0
                  ^
Check the log at /home/brutus/.cache/pre-commit/pre-commit.log
```

Quoting `@prettier/plugin-xml@0.12.0` seem to work.