### PR TITLE
Remove the ``--list-different`` option for 4.0.0 compatibility

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: prettier
     name: prettier
     description: ''
-    entry: prettier --write --list-different --ignore-unknown
+    entry: prettier --write --ignore-unknown
     language: node
     'types': [text]
     args: []


### PR DESCRIPTION
When using ``v4.0.0alpha3`` we now encounter the following error:

```
The "--list-different" and "--write" flags cannot be used together
```

``pre-commit`` fails when a file is modified by an autofixxer so ``--list-different`` can be removed afaiu.