### PR TITLE
Remove the ``--list-different`` option for 4.0.0 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - run: pip install pre-commit-mirror-maker
     - run: git config --global user.name 'Github Actions'
     - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-    - run: pre-commit-mirror . --language=node --package-name=prettier --types=text --entry='prettier --write --list-different --ignore-unknown' --id=prettier
+    - run: pre-commit-mirror . --language=node --package-name=prettier --types=text --entry='prettier --write --ignore-unknown' --id=prettier
     - run: |
         git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
Follow-up to #50.

When using ``v4.0.0alpha3`` we now encounter the following error:

```
The "--list-different" and "--write" flags cannot be used together
```

``pre-commit`` fails when a file is modified by an autofixxer so ``--list-different`` can be removed afaiu.